### PR TITLE
Fixed middle pane problem

### DIFF
--- a/frontend/src/features/textView/TextSegment.tsx
+++ b/frontend/src/features/textView/TextSegment.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import {
   activeSegmentMatchesAtom,
   hoveredOverParallelIdAtom,
@@ -62,6 +62,7 @@ export const TextSegment = ({
   const updateSelectedLocationInGlobalState = useCallback(
     async (location: { id: string; index: number; matches: string[] }) => {
       setIsMiddlePanePointingLeft(isRightPane);
+      setSelectedSegmentMatches(location.matches);
       await Promise.all([
         setActiveSegmentId(location.id),
         setActiveSegmentIndex(location.index),
@@ -74,29 +75,7 @@ export const TextSegment = ({
       setActiveSegmentId,
       setActiveSegmentIndex,
       setIsMiddlePanePointingLeft,
-    ],
-  );
-
-  // find matches for the selected segment when the page is first rendered
-  useLayoutEffect(
-    function openMiddlePaneWithMatches() {
-      if (!isSegmentSelected || typeof activeSegmentIndex !== "number") return;
-      const segmentInData = data?.segmentText[activeSegmentIndex];
-      if (!segmentInData) return;
-      if (isRightPane && isMiddlePanePointingLeft) {
-        setSelectedSegmentMatches(segmentInData.matches);
-      } else if (!isRightPane && !isMiddlePanePointingLeft) {
-        setSelectedSegmentMatches(segmentInData.matches);
-      }
-    },
-    [
-      isSegmentSelected,
-      data?.segmentText,
-      activeSegmentId,
-      activeSegmentIndex,
       setSelectedSegmentMatches,
-      isRightPane,
-      isMiddlePanePointingLeft,
     ],
   );
 

--- a/frontend/src/features/textView/TextSegment.tsx
+++ b/frontend/src/features/textView/TextSegment.tsx
@@ -53,7 +53,7 @@ export const TextSegment = ({
   const setSelectedSegmentMatches = useSetAtom(activeSegmentMatchesAtom);
   const isSegmentSelected = activeSegmentId === data?.segmentNumber;
 
-  const [isMiddlePanePointingLeft, setIsMiddlePanePointingLeft] = useAtom(
+  const [, setIsMiddlePanePointingLeft] = useAtom(
     textViewIsMiddlePanePointingLeftAtom,
   );
 

--- a/frontend/src/features/textView/TextView.tsx
+++ b/frontend/src/features/textView/TextView.tsx
@@ -1,6 +1,7 @@
 import "allotment/dist/style.css";
 
 import React, { useEffect, useRef } from "react";
+import { activeSegmentMatchesAtom } from "@atoms";
 import {
   useActiveSegmentParam,
   useRightPaneActiveSegmentParam,
@@ -10,6 +11,7 @@ import { TextViewLeftPane } from "@features/textView/TextViewLeftPane";
 import { TextViewRightPane } from "@features/textView/TextViewRightPane";
 import { Paper } from "@mui/material";
 import { Allotment, AllotmentHandle, LayoutPriority } from "allotment";
+import { useAtomValue } from "jotai";
 
 import TextViewMiddleParallels from "./TextViewMiddleParallels";
 
@@ -17,10 +19,12 @@ import TextViewMiddleParallels from "./TextViewMiddleParallels";
 export const TextView = () => {
   const [activeSegmentId] = useActiveSegmentParam();
   const [rightPaneActiveSegmentId] = useRightPaneActiveSegmentParam();
+  const activeSegmentMatches = useAtomValue(activeSegmentMatchesAtom);
 
   const allotmentRef = useRef<AllotmentHandle>(null);
 
-  const shouldShowMiddlePane = activeSegmentId !== "none";
+  const shouldShowMiddlePane =
+    activeSegmentId !== "none" && activeSegmentMatches.length > 0;
 
   const shouldShowRightPane =
     rightPaneActiveSegmentId !== DEFAULT_PARAM_VALUES.active_segment;


### PR DESCRIPTION
This fixes the problem we have with external links opening the middle view unintentionally (=weird behavior for MITRASearch etc). I hope this doesn't break any other functionality -- I tested with a few texts and scenarios and it *seems* OK 