### PR TITLE
fix to our active-segment bug 

### DIFF
--- a/frontend/src/components/hooks/params.ts
+++ b/frontend/src/components/hooks/params.ts
@@ -92,7 +92,7 @@ export const useActiveSegmentParam = () => {
 export const useActiveSegmentIndexParam = () => {
   return useQueryState(
     allUIComponentParamNames.active_segment_index,
-    parseAsInteger,
+    parseAsInteger.withDefault(DEFAULT_PARAM_VALUES.active_segment_index),
   );
 };
 
@@ -106,7 +106,9 @@ export const useRightPaneActiveSegmentParam = () => {
 export const useRightPaneActiveSegmentIndexParam = () => {
   return useQueryState(
     allUIComponentParamNames.right_pane_active_segment_index,
-    parseAsInteger,
+    parseAsInteger.withDefault(
+      DEFAULT_PARAM_VALUES.right_pane_active_segment_index,
+    ),
   );
 };
 

--- a/frontend/src/features/SidebarSuite/uiSettings/config.ts
+++ b/frontend/src/features/SidebarSuite/uiSettings/config.ts
@@ -99,6 +99,8 @@ export const DEFAULT_PARAM_VALUES = {
   },
   sort_method: "position",
   active_segment: "none",
+  active_segment_index: 0,
+  right_pane_active_segment_index: 0,
   active_match: "",
   include_matches: false,
 } as const;

--- a/frontend/src/features/textView/useTextViewPane.ts
+++ b/frontend/src/features/textView/useTextViewPane.ts
@@ -159,6 +159,12 @@ export function useTextViewPane({
   });
 
   useEffect(() => {
+    // When filters change, we need to reset the selected segments map.
+    // This ensures that the active_segment is passed to the BE on the first request.
+    previouslySelectedSegmentsMap.current = {};
+  }, [requestBodyBase]);
+
+  useEffect(() => {
     if (isFetchedAfterMount) {
       previousFileName.current = fileName;
     }


### PR DESCRIPTION
this adresses #27 -- there is still a lingering issue with the fact that after triggering endless scrolling up/down and then changing a filter setting, the text-view jumps back, but that is harder to fix. We can address that in the future, its not an issue people are likely to run into in the first months of the platform being live. 