### PR TITLE
Re-introduced and fixed folio selector behavior + fixed language selector in table view 

### DIFF
--- a/frontend/src/features/SidebarSuite/SidebarBody/SidebarBody.tsx
+++ b/frontend/src/features/SidebarSuite/SidebarBody/SidebarBody.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "next-i18next";
+import { currentDbViewAtom } from "@atoms";
 import { useIncludeMatchesParam } from "@components/hooks/params";
 import { CollapsibleSection } from "@features/SidebarSuite/common/CollapsibleSection";
 import { DrawerHeader } from "@features/SidebarSuite/common/MuiStyledSidebarComponents";
@@ -13,8 +14,11 @@ import { ResetFiltersButton } from "@features/SidebarSuite/uiSettings/ResetFilte
 import ScoreFilter from "@features/SidebarSuite/uiSettings/ScoreFilter";
 import { ShowSegmentNumbersSwitch } from "@features/SidebarSuite/uiSettings/ShowSegmentNumbersSwitch";
 import { TibetanScriptSelector } from "@features/SidebarSuite/uiSettings/TextScriptSelectors";
+import TextViewFolioNavigation from "@features/SidebarSuite/uiSettings/TextViewFolioNavigation";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import { Box, IconButton, Typography } from "@mui/material";
+import { DbViewEnum } from "@utils/constants";
+import { useAtomValue } from "jotai";
 
 import { UtilityOptionsSection } from "./UtilityOptionsSection/UtilityOptionsSection";
 
@@ -51,6 +55,7 @@ export function SidebarBody({
 }) {
   const [includeMatches] = useIncludeMatchesParam();
   const { t } = useTranslation("settings");
+  const currentView = useAtomValue(currentDbViewAtom);
 
   return (
     <>
@@ -73,6 +78,7 @@ export function SidebarBody({
           <MonochromaticHighlightSwitch />
           <TibetanScriptSelector />
           <FontSizeSlider />
+          {currentView === DbViewEnum.TEXT && <TextViewFolioNavigation />}
         </CollapsibleSection>
 
         <CollapsibleSection title={t("headings.filters")}>
@@ -88,7 +94,7 @@ export function SidebarBody({
             <ParLengthFilter />
             <DbSourceFilter filterName="exclude_sources" />
             <DbSourceFilter filterName="include_sources" />
-            <FolioOption />
+            {currentView !== DbViewEnum.TEXT && <FolioOption />}
           </Box>
         </CollapsibleSection>
 

--- a/frontend/src/features/SidebarSuite/SidebarBody/SidebarBody.tsx
+++ b/frontend/src/features/SidebarSuite/SidebarBody/SidebarBody.tsx
@@ -89,7 +89,7 @@ export function SidebarBody({
             }}
           >
             <ResetFiltersButton />
-            <MultiLingualSelector />
+            {currentView === DbViewEnum.TEXT && <MultiLingualSelector />}
             <ScoreFilter />
             <ParLengthFilter />
             <DbSourceFilter filterName="exclude_sources" />

--- a/frontend/src/features/SidebarSuite/uiSettings/TextViewFolioNavigation.tsx
+++ b/frontend/src/features/SidebarSuite/uiSettings/TextViewFolioNavigation.tsx
@@ -1,0 +1,126 @@
+import { useTranslation } from "next-i18next";
+import { useActiveSegmentParam } from "@components/hooks/params";
+import { useDbPageRouterParams } from "@components/hooks/useDbRouterParams";
+import {
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  OutlinedInput,
+  Select,
+  SelectChangeEvent,
+} from "@mui/material";
+import Box from "@mui/material/Box";
+import { useQuery } from "@tanstack/react-query";
+import { DbApi } from "@utils/api/dbApi";
+
+function SelectorFrame({
+  children,
+  label,
+}: {
+  children: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <Box sx={{ width: 1, my: 2 }}>
+      <FormControl sx={{ width: 1 }} title={label}>
+        <InputLabel id="text-view-folio-navigation-label">{label}</InputLabel>
+        {children}
+      </FormControl>
+    </Box>
+  );
+}
+
+function Loading({ showAll, label }: { showAll: string; label: string }) {
+  return (
+    <Select
+      labelId="text-view-folio-navigation-label"
+      value={showAll}
+      inputProps={{
+        id: "text-view-folio-navigation",
+      }}
+      input={<OutlinedInput label={label} />}
+      displayEmpty
+    >
+      <MenuItem value={showAll}>
+        <em>{showAll}</em>
+      </MenuItem>
+      <MenuItem value="loading">
+        <CircularProgress color="inherit" size={20} />
+      </MenuItem>
+    </Select>
+  );
+}
+
+export default function TextViewFolioNavigation() {
+  const { t } = useTranslation("settings");
+  const { fileName } = useDbPageRouterParams();
+  const [, setActiveSegment] = useActiveSegmentParam();
+
+  const { data, isLoading } = useQuery({
+    queryKey: DbApi.FolioData.makeQueryKey(fileName),
+    queryFn: () => DbApi.FolioData.call({ filename: fileName }),
+  });
+
+  const showAll = t("optionsLabels.folioShowAll");
+
+  const handleSelectChange = async (event: SelectChangeEvent) => {
+    const { value } = event.target;
+
+    if (value === showAll) {
+      // Reset to no active segment
+      await setActiveSegment("none");
+      return;
+    }
+
+    // Get the active segment for the selected folio
+    try {
+      const activeSegment = await DbApi.ActiveSegmentForFolio.call({
+        filename: fileName,
+        folio: value,
+      });
+
+      if (activeSegment) {
+        await setActiveSegment(activeSegment);
+      }
+    } catch {
+      // Silently handle error - user can try again
+    }
+  };
+
+  const label = t("optionsLabels.folioAsGoTo");
+
+  if (isLoading) {
+    return (
+      <SelectorFrame label={label}>
+        <Loading showAll={showAll} label={label} />
+      </SelectorFrame>
+    );
+  }
+
+  return (
+    <SelectorFrame label={label}>
+      <Select
+        labelId="text-view-folio-navigation-label"
+        inputProps={{
+          id: "text-view-folio-navigation",
+        }}
+        input={<OutlinedInput label={label} />}
+        value={showAll}
+        displayEmpty
+        onChange={handleSelectChange}
+      >
+        <MenuItem value={showAll}>
+          <em>{showAll}</em>
+        </MenuItem>
+        {data?.map((folio: string) => {
+          return (
+            <MenuItem key={folio} value={folio}>
+              {folio}
+            </MenuItem>
+          );
+        })}
+      </Select>
+    </SelectorFrame>
+  );
+}

--- a/frontend/src/utils/api/dbApi.ts
+++ b/frontend/src/utils/api/dbApi.ts
@@ -10,6 +10,7 @@ import { getNumbersViewData } from "./endpoints/numbers-view/numbers";
 import { getTableData } from "./endpoints/table-view/table";
 import { getTextViewMiddleParallelsData } from "./endpoints/text-view/middle";
 import { getTextViewParallelsData } from "./endpoints/text-view/text-parallels";
+import { getActiveSegmentForFolio } from "./endpoints/utils/active-segment-for-folio";
 import { getCountMatches } from "./endpoints/utils/count-matches";
 import { getTextDisplayName } from "./endpoints/utils/displayname";
 import { getFolios } from "./endpoints/utils/folios";
@@ -68,6 +69,14 @@ export const DbApi = {
   FolioData: {
     makeQueryKey: (fileName: string) => ["foliosData", fileName],
     call: getFolios,
+  },
+  ActiveSegmentForFolio: {
+    makeQueryKey: (fileName: string, folio: string) => [
+      "activeSegmentForFolio",
+      fileName,
+      folio,
+    ],
+    call: getActiveSegmentForFolio,
   },
   ExternalLinksData: {
     makeQueryKey: (fileName: string) => ["externalLinkData", fileName],

--- a/frontend/src/utils/api/endpoints/utils/active-segment-for-folio.ts
+++ b/frontend/src/utils/api/endpoints/utils/active-segment-for-folio.ts
@@ -1,0 +1,12 @@
+import apiClient from "@api";
+import type { APIGetRequestQuery } from "@utils/api/types";
+
+export async function getActiveSegmentForFolio(
+  query: APIGetRequestQuery<"/utils/active-segment-for-folio/">,
+) {
+  const { data } = await apiClient.GET("/utils/active-segment-for-folio/", {
+    params: { query },
+  });
+
+  return data?.active_segment ?? "";
+}


### PR DESCRIPTION
This does three things: 
1. re-introduce the folio dropdown selector as a display option in the text view 
2. Introduce it as a filter option in the text-view 
3. Disable language filter in the table-view (we don't have multilingual matches there)
I don't really know what we should do with numbers view here -- that is, to be fair. ven. Vimala's turf, I am out of the numbers view game for some years unfortunately... 